### PR TITLE
Refactor WeightedExperience property in ResourceTag class

### DIFF
--- a/me.shared/Models/ResourceTag.cs
+++ b/me.shared/Models/ResourceTag.cs
@@ -11,5 +11,13 @@ public class ResourceTag
     [JsonIgnore]
     public virtual Tag Tag { get; set; }
     [JsonIgnore]
-    public double WeightedExperience => Resource.Experience / Resource.ResourceTags.Where(rt => rt.Tag.Type == Tag.Type).Count();
+    public double WeightedExperience
+    {
+        get
+        {
+            var resourceTagTypes = Resource.ResourceTags.Select(rt => rt.Tag.Type).Distinct();
+            var taggedResourceTags = Resource.ResourceTags.Where(rt => rt.Tag.Type == Tag.Type);
+            return Resource.Experience / resourceTagTypes.Count() / taggedResourceTags.Count();
+        }
+    }
 }


### PR DESCRIPTION
Refactored the `WeightedExperience` property from a single-line expression to a full property with a getter method. The new implementation improves readability and maintainability by:
1. Retrieving distinct `Tag.Type` values from `Resource.ResourceTags`.
2. Filtering `Resource.ResourceTags` to include only those with the same `Tag.Type` as the current `ResourceTag`.
3. Calculating the weighted experience by dividing `Resource.Experience` by the count of distinct `Tag.Type` values and the count of filtered `ResourceTags`.