### PR TITLE
Refine filtering logic for resource tag summation

### DIFF
--- a/me/Pages/AboutMe.razor
+++ b/me/Pages/AboutMe.razor
@@ -59,9 +59,9 @@
             var highlightedTags = Data.Tags.Where(t => t.IsHighlighted);
             return highlightedTags.Any() || selectedResourceTypes.Any()
                 ? FilteredResources
-                    .Where(r => !selectedResourceTypes.Any() || r.Type.IsSelected)
                     .SelectMany(r => r.ResourceTags)
-                    .Where(rt => highlightedTags.Contains(rt.Tag))
+                    .Where(rt => (!highlightedTags.Any() || highlightedTags.Contains(rt.Tag))
+                        || (!selectedResourceTypes.Any() || selectedResourceTypes.Contains(rt.Resource.TypeId)))
                     .Sum(t => t.WeightedExperience)
                 : _totalXP;
         }


### PR DESCRIPTION
The code modification refines the filtering logic for calculating the weighted experience of resource tags. The new logic includes resource tags if either no tags are highlighted or the tag is highlighted, and additionally, if either no resource types are selected or the resource type of the tag matches a selected resource type. This enhances the flexibility and inclusiveness of the filtering criteria.